### PR TITLE
feat: prevent LLM scraping via robots.txt and meta tags

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,65 @@
 User-agent: *
 Disallow: /admin/
 
+# LLM / AI training crawlers
+User-agent: GPTBot
+Disallow: /
+
+User-agent: ChatGPT-User
+Disallow: /
+
+User-agent: OAI-SearchBot
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: Claude-Web
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: Gemini-Web
+Disallow: /
+
+User-agent: Googlebot-Extended
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: PerplexityBot
+Disallow: /
+
+User-agent: Diffbot
+Disallow: /
+
+User-agent: cohere-ai
+Disallow: /
+
+User-agent: FacebookBot
+Disallow: /
+
+User-agent: Applebot-Extended
+Disallow: /
+
+User-agent: omgilibot
+Disallow: /
+
+User-agent: omgili
+Disallow: /
+
+User-agent: DataForSeoBot
+Disallow: /
+
+User-agent: img2dataset
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
 Sitemap: https://timfontes.com/sitemap-index.xml

--- a/src/components/Shell/index.astro
+++ b/src/components/Shell/index.astro
@@ -53,7 +53,8 @@ const feedPath = {
     <meta name="theme-color" content="#d3e5fa" />
     <link rel="sitemap" href="/sitemap-index.xml" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="robots" content="index, follow" />
+    <meta name="robots" content="index, follow, noai, noimageai" />
+    <meta name="tdm-reservation" content="1" />
 
     <link rel="canonical" href={canonicalURL} />
     <meta name="description" content={usedDescription} />


### PR DESCRIPTION
Block 18 known AI training crawlers in robots.txt and add noai/noimageai meta directives plus W3C TDM reservation to the shell head.